### PR TITLE
Python3 support

### DIFF
--- a/azure_ad_auth/backends.py
+++ b/azure_ad_auth/backends.py
@@ -69,4 +69,4 @@ class AzureActiveDirectoryBackend(object):
 
     @staticmethod
     def username_generator(email):
-        return urlsafe_b64encode(sha1(email).digest()).rstrip(b'=')
+        return urlsafe_b64encode(sha1(email.encode('utf-8')).digest()).rstrip(b'=')

--- a/azure_ad_auth/utils.py
+++ b/azure_ad_auth/utils.py
@@ -5,7 +5,12 @@ from django.conf import settings
 import jwt
 from lxml import etree
 import requests
-from urllib import urlencode
+try:
+    # Python 3
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2
+    from urllib import urlencode
 
 
 AUTHORITY = getattr(settings, 'AAD_AUTHORITY', 'https://login.microsoftonline.com')

--- a/azure_ad_auth/views.py
+++ b/azure_ad_auth/views.py
@@ -5,8 +5,13 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.cache import never_cache
-import urlparse
 import uuid
+try:
+    # Python 3
+    from urllib.parse import urlparse
+except ImportError:
+    # Python 2
+    import urlparse
 
 
 @never_cache

--- a/azure_ad_auth/views.py
+++ b/azure_ad_auth/views.py
@@ -11,7 +11,7 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     # Python 2
-    import urlparse
+    from urlparse import urlparse
 
 
 @never_cache
@@ -49,7 +49,7 @@ def complete(request):
 
 def get_login_success_url(request):
     redirect_to = request.GET.get(REDIRECT_FIELD_NAME, '')
-    netloc = urlparse.urlparse(redirect_to)[1]
+    netloc = urlparse(redirect_to)[1]
     if not redirect_to:
         redirect_to = settings.LOGIN_REDIRECT_URL
     elif netloc and netloc != request.get_host():


### PR DESCRIPTION
Add backward compatible import for python3
Unfortunately the `.encode('utf-8')` bit will most likely fail in python2 😞 