### PR TITLE
Add request parameter

### DIFF
--- a/azure_ad_auth/backends.py
+++ b/azure_ad_auth/backends.py
@@ -37,7 +37,7 @@ class AzureActiveDirectoryBackend(object):
     def logout_url(redirect_uri):
         return get_logout_url(redirect_uri=redirect_uri)
 
-    def authenticate(self, token=None, nonce=None, **kwargs):
+    def authenticate(self, request=None, token=None, nonce=None, **kwargs):
         if token is None:
             return None
 

--- a/azure_ad_auth/views.py
+++ b/azure_ad_auth/views.py
@@ -46,7 +46,7 @@ def complete(request):
     if original_state == state:
         token = getattr(request, method).get('id_token')
         nonce = request.session.get('nonce')
-        user = backend.authenticate(token=token, nonce=nonce)
+        user = backend.authenticate(request=request, token=token, nonce=nonce)
         if user is not None:
             login(request, user)
             return HttpResponseRedirect(get_login_success_url(request))


### PR DESCRIPTION
The `authenticate` method receives `request` as the first argument when being called via [`django.contrib.auth.authenticate`](https://docs.djangoproject.com/en/2.2/topics/auth/default/#django.contrib.auth.authenticate)

Source: https://docs.djangoproject.com/en/2.2/topics/auth/customizing/#writing-an-authentication-backend